### PR TITLE
Remove/Improve Startup delay: Remove conditional import of ForwardPattern 

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -33,10 +33,6 @@ from .utils import (
     apply_noise_injection,
 )
 
-try:
-    from cache_dit.caching import ForwardPattern
-except ImportError:
-    ForwardPattern = None
 
 if TYPE_CHECKING:
     from comfy.model_patcher import ModelPatcher


### PR DESCRIPTION
This node previously increased ComfyUI startup time because nodes.py imported cache_dit.caching at module load. That import triggers the full cache_dit import chain, which eagerly loads diffusers and other heavy ML dependencies before the node is ever used.

Removing that eager import improves startup performance, especially for users with many custom nodes or users who don’t use this node often

This should remove most or all of the startup delay caused by this node itself. Node still works as it should, one-time delay moved to when node is actually used.

Before:
<img width="1011" height="27" alt="image" src="https://github.com/user-attachments/assets/c686f019-5d27-4d87-a902-4577e762d47b" />

After:
<img width="851" height="23" alt="image" src="https://github.com/user-attachments/assets/0294d0cb-4bae-4319-9275-b4400bdd7525" />
